### PR TITLE
Complete platform tools cache by making `temp` crate a SBPF program

### DIFF
--- a/docker/v1.18.25.Dockerfile
+++ b/docker/v1.18.25.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:b7b25312e49dfbe6cab04c89d5a8ed5df2df9714
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.25/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v1.18.26.Dockerfile
+++ b/docker/v1.18.26.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:b7b25312e49dfbe6cab04c89d5a8ed5df2df9714
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.26/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.0.Dockerfile
+++ b/docker/v2.0.0.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.0/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.1.Dockerfile
+++ b/docker/v2.0.1.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.1/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.10.Dockerfile
+++ b/docker/v2.0.10.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.10/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.11.Dockerfile
+++ b/docker/v2.0.11.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.11/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.13.Dockerfile
+++ b/docker/v2.0.13.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.13/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.14.Dockerfile
+++ b/docker/v2.0.14.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.14/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.15.Dockerfile
+++ b/docker/v2.0.15.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.15/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.16.Dockerfile
+++ b/docker/v2.0.16.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.16/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.17.Dockerfile
+++ b/docker/v2.0.17.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.17/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.18.Dockerfile
+++ b/docker/v2.0.18.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.18/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.19.Dockerfile
+++ b/docker/v2.0.19.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.19/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.2.Dockerfile
+++ b/docker/v2.0.2.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.2/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.20.Dockerfile
+++ b/docker/v2.0.20.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.20/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.21.Dockerfile
+++ b/docker/v2.0.21.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.21/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.22.Dockerfile
+++ b/docker/v2.0.22.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.22/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.23.Dockerfile
+++ b/docker/v2.0.23.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.23/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.24.Dockerfile
+++ b/docker/v2.0.24.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.24/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.25.Dockerfile
+++ b/docker/v2.0.25.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.25/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.3.Dockerfile
+++ b/docker/v2.0.3.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.3/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.4.Dockerfile
+++ b/docker/v2.0.4.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.4/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.5.Dockerfile
+++ b/docker/v2.0.5.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.5/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.6.Dockerfile
+++ b/docker/v2.0.6.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.6/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.7.Dockerfile
+++ b/docker/v2.0.7.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.7/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.8.Dockerfile
+++ b/docker/v2.0.8.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.8/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.0.9.Dockerfile
+++ b/docker/v2.0.9.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153f
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.9/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.0.Dockerfile
+++ b/docker/v2.1.0.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.0/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.1.Dockerfile
+++ b/docker/v2.1.1.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.1/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.10.Dockerfile
+++ b/docker/v2.1.10.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.10/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.11.Dockerfile
+++ b/docker/v2.1.11.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.11/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.13.Dockerfile
+++ b/docker/v2.1.13.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.13/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.14.Dockerfile
+++ b/docker/v2.1.14.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.14/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.15.Dockerfile
+++ b/docker/v2.1.15.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.15/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.16.Dockerfile
+++ b/docker/v2.1.16.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.16/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.17.Dockerfile
+++ b/docker/v2.1.17.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.17/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.18.Dockerfile
+++ b/docker/v2.1.18.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.18/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.2.Dockerfile
+++ b/docker/v2.1.2.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.2/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.20.Dockerfile
+++ b/docker/v2.1.20.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.20/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.21.Dockerfile
+++ b/docker/v2.1.21.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.21/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.4.Dockerfile
+++ b/docker/v2.1.4.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.4/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.5.Dockerfile
+++ b/docker/v2.1.5.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.5/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.6.Dockerfile
+++ b/docker/v2.1.6.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.6/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.7.Dockerfile
+++ b/docker/v2.1.7.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.7/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.8.Dockerfile
+++ b/docker/v2.1.8.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.8/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.1.9.Dockerfile
+++ b/docker/v2.1.9.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.9/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.0.Dockerfile
+++ b/docker/v2.2.0.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.0/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.1.Dockerfile
+++ b/docker/v2.2.1.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.1/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.10.Dockerfile
+++ b/docker/v2.2.10.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.10/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.11.Dockerfile
+++ b/docker/v2.2.11.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.11/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.12.Dockerfile
+++ b/docker/v2.2.12.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.12/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.13.Dockerfile
+++ b/docker/v2.2.13.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.13/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.14.Dockerfile
+++ b/docker/v2.2.14.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.14/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.15.Dockerfile
+++ b/docker/v2.2.15.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.15/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.16.Dockerfile
+++ b/docker/v2.2.16.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.16/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.17.Dockerfile
+++ b/docker/v2.2.17.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.17/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.18.Dockerfile
+++ b/docker/v2.2.18.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.18/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.19.Dockerfile
+++ b/docker/v2.2.19.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.19/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.2.Dockerfile
+++ b/docker/v2.2.2.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.2/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.20.Dockerfile
+++ b/docker/v2.2.20.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.20/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.3.Dockerfile
+++ b/docker/v2.2.3.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.3/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.4.Dockerfile
+++ b/docker/v2.2.4.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.4/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.6.Dockerfile
+++ b/docker/v2.2.6.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.6/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.7.Dockerfile
+++ b/docker/v2.2.7.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.7/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.8.Dockerfile
+++ b/docker/v2.2.8.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.8/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.2.9.Dockerfile
+++ b/docker/v2.2.9.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e12
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.9/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.0.Dockerfile
+++ b/docker/v2.3.0.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.0/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.1.Dockerfile
+++ b/docker/v2.3.1.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.1/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.10.Dockerfile
+++ b/docker/v2.3.10.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.10/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.11.Dockerfile
+++ b/docker/v2.3.11.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.11/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.12.Dockerfile
+++ b/docker/v2.3.12.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.12/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.13.Dockerfile
+++ b/docker/v2.3.13.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.2.Dockerfile
+++ b/docker/v2.3.2.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.2/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.3.Dockerfile
+++ b/docker/v2.3.3.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.3/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.4.Dockerfile
+++ b/docker/v2.3.4.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.4/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.5.Dockerfile
+++ b/docker/v2.3.5.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.5/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.6.Dockerfile
+++ b/docker/v2.3.6.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.6/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.7.Dockerfile
+++ b/docker/v2.3.7.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.7/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.8.Dockerfile
+++ b/docker/v2.3.8.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.8/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v2.3.9.Dockerfile
+++ b/docker/v2.3.9.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.9/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v3.0.0.Dockerfile
+++ b/docker/v3.0.0.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.0/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v3.0.1.Dockerfile
+++ b/docker/v3.0.1.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.1/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v3.0.2.Dockerfile
+++ b/docker/v3.0.2.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.2/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v3.0.3.Dockerfile
+++ b/docker/v3.0.3.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.3/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v3.0.4.Dockerfile
+++ b/docker/v3.0.4.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.4/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v3.0.5.Dockerfile
+++ b/docker/v3.0.5.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.5/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v3.0.6.Dockerfile
+++ b/docker/v3.0.6.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.6/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/docker/v3.0.7.Dockerfile
+++ b/docker/v3.0.7.Dockerfile
@@ -3,10 +3,13 @@ FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.7/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \
     cd temp && \
-    cargo build-sbf && \
+    echo "[lib]" >> Cargo.toml && \
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \
+    cargo test-sbf && \
+    cd ../ && \
     rm -rf temp
 WORKDIR /build
 

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -57,10 +57,13 @@ FROM --platform=linux/amd64 rust@{RUST_VERSION_PLACEHOLDER}
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/{AGAVE_VERSION_PLACEHOLDER}/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-# Call cargo build-sbf to trigger installation of associated platform tools
-RUN cargo init temp --edition 2021 && \\
+# Call cargo test-sbf to trigger installation of associated platform tools
+RUN cargo init --lib temp --edition 2021 && \\
     cd temp && \\
-    cargo build-sbf && \\
+    echo "[lib]" >> Cargo.toml && \\
+    echo 'crate-type = ["cdylib", "lib"]' >> Cargo.toml && \\
+    cargo test-sbf && \\
+    cd ../ && \\
     rm -rf temp
 WORKDIR /build
 


### PR DESCRIPTION
## Description

Building off #202 

#202 downloads the platform tools, but `cargo build-sbf` appears to run further setup steps when it tries to compile a SBPF program for the first time. These further setup steps involve downloading criterion and switching out the toolchain. Dump of stdout is pasted in appendix section below for visibility.

This PR makes sure that those setup steps are ran as well by marking the `temp/` repo as a SBPF program by setting

```
[lib]
crate-type = ["cdylib", "lib"]
```

in  `Cargo.toml`.

## Other
- cleans up `temp/` folder by `cd ../` before removing it
- change `cargo build-sbf` to `cargo test-sbf` in case the test step performs any additional setup (doesn't look like it does)

P.S. the bash command is getting a little unwieldy, idk if you guys want to factor it out into a bash script or something like that.

P.P.S the right thing to do would probably be to further figure out why the initial setup involves downloading a `criterion` release. Seems wholly unnecessary.

## Appendix: setup stdout dump

```
+ wget https://github.com/Snaipe/Criterion/releases/download/v2.3.3/criterion-v2.3.3-linux-x86_64.tar.bz2 -O criterion-v2.3.3-linux-x86_64.tar.bz2 --progress=dot:giga --retry-connrefused --read-timeout=30
--2025-11-18 08:34:59--  https://github.com/Snaipe/Criterion/releases/download/v2.3.3/criterion-v2.3.3-linux-x86_64.tar.bz2
Resolving github.com (github.com)... 20.205.243.166
Connecting to github.com (github.com)|20.205.243.166|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://release-assets.githubusercontent.com/github-production-release-asset/30111969/98b27400-e1f1-11e8-8f10-e43f4ef84b92?sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-11-18T09%3A20%3A47Z&rscd=attachment%3B+filename%3Dcriterion-v2.3.3-linux-x86_64.tar.bz2&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2025-11-18T08%3A20%3A42Z&ske=2025-11-18T09%3A20%3A47Z&sks=b&skv=2018-11-09&sig=JR9I5t4cCOsqtCWs2f7kwky%2BP0Xeru0IX1ZzSicmQms%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc2MzQ1NTE5OSwibmJmIjoxNzYzNDU0ODk5LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.95LsZcQ8RbLyMZ7pTrICIDBZ6oiLSX7dd254GTzTXpw&response-content-disposition=attachment%3B%20filename%3Dcriterion-v2.3.3-linux-x86_64.tar.bz2&response-content-type=application%2Foctet-stream [following]
--2025-11-18 08:35:00--  https://release-assets.githubusercontent.com/github-production-release-asset/30111969/98b27400-e1f1-11e8-8f10-e43f4ef84b92?sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-11-18T09%3A20%3A47Z&rscd=attachment%3B+filename%3Dcriterion-v2.3.3-linux-x86_64.tar.bz2&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2025-11-18T08%3A20%3A42Z&ske=2025-11-18T09%3A20%3A47Z&sks=b&skv=2018-11-09&sig=JR9I5t4cCOsqtCWs2f7kwky%2BP0Xeru0IX1ZzSicmQms%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc2MzQ1NTE5OSwibmJmIjoxNzYzNDU0ODk5LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.95LsZcQ8RbLyMZ7pTrICIDBZ6oiLSX7dd254GTzTXpw&response-content-disposition=attachment%3B%20filename%3Dcriterion-v2.3.3-linux-x86_64.tar.bz2&response-content-type=application%2Foctet-stream
Resolving release-assets.githubusercontent.com (release-assets.githubusercontent.com)... 185.199.109.133, 185.199.108.133, 185.199.111.133, ...
Connecting to release-assets.githubusercontent.com (release-assets.githubusercontent.com)|185.199.109.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 677858 (662K) [application/octet-stream]
Saving to: 'criterion-v2.3.3-linux-x86_64.tar.bz2'

     0K                                    100% 10.7M=0.06s

2025-11-18 08:35:00 (10.7 MB/s) - 'criterion-v2.3.3-linux-x86_64.tar.bz2' saved [677858/677858]

+ tar --strip-components 1 -jxf criterion-v2.3.3-linux-x86_64.tar.bz2
+ ./platform-tools/rust/bin/rustc --version
+ ./platform-tools/rust/bin/rustc --print sysroot
+ [[ 5 -lt 4 ]]
+ mapfile -t toolchains
++ rustup toolchain list
+ set +e
+ for item in "${toolchains[@]}"
+ [[ 1.89.0-sbpf-solana-v1.52 == *\s\o\l\a\n\a* ]]
+ rustup toolchain uninstall 1.89.0-sbpf-solana-v1.52
info: uninstalling toolchain '1.89.0-sbpf-solana-v1.52'
info: toolchain '1.89.0-sbpf-solana-v1.52' uninstalled
+ for item in "${toolchains[@]}"
+ [[ 1.89.0-x86_64-unknown-linux-gnu (active, default) == *\s\o\l\a\n\a* ]]
+ set -e
+ rustup toolchain link 1.89.0-sbpf-solana-v1.52 platform-tools/rust
+ exit 0
```