### PR TITLE
Add checksum verification for Solana/Agave installers in Dockerfiles

### DIFF
--- a/.github/workflows/update_existing_dockerfile_checksums.yml
+++ b/.github/workflows/update_existing_dockerfile_checksums.yml
@@ -1,0 +1,51 @@
+name: Update Existing Dockerfile Installer Checksums
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_existing_dockerfile_checksums:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install dependencies with uv
+        run: |
+          uv sync --all-extras --dev
+
+      - name: Update installer checksum pins in existing Dockerfiles
+        run: uv run generate_dockerfiles.py --skip_cache --update_existing --only_existing
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          commit-message: Update existing installer checksum pins
+          title: "Update Existing Installer Checksums"
+          body: |
+            This PR updates `docker/v*.Dockerfile` entries for installer checksum pinning.
+
+            Changes are generated automatically by the "Update Existing Dockerfile Installer Checksums" workflow.
+          branch: autopr-update-existing-installer-checksums
+          delete-branch: true
+          base: master
+          labels: |
+            automated pr
+            installer checksums
+

--- a/docker/v1.18.25.Dockerfile
+++ b/docker/v1.18.25.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:b7b25312e49dfbe6cab04c89d5a8ed5df2df971406a3b5c5ac43e247b5821b5f
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.25/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v1.18.25/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "dfd7132b5c4b12054d20dd0e1d6488cbe65263b449429a1c8000ff76d88b5787" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v1.18.26.Dockerfile
+++ b/docker/v1.18.26.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:b7b25312e49dfbe6cab04c89d5a8ed5df2df971406a3b5c5ac43e247b5821b5f
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v1.18.26/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v1.18.26/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "cec72cde1cf36eb35cd8326245d23af0b6791fab68337c2953e2ca2a40af2c50" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.0.Dockerfile
+++ b/docker/v2.0.0.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.0/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.0/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "29626826d1266c1df886e0e67f59f2957770e6feec3514071554a1ae7ec1e28c" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.1.Dockerfile
+++ b/docker/v2.0.1.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.1/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.1/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "a6acf9b2e2cbd0d513046d3e7fba91c1fabf356ccb5c69cc95c5c4345bd7f16a" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.10.Dockerfile
+++ b/docker/v2.0.10.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.10/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.10/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "f15b0c1591f9d4c329d7c256a4fa7b5bcfeb2a5dc9b1c7f1793690f5825a0cf0" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.11.Dockerfile
+++ b/docker/v2.0.11.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.11/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.11/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "d819c549db91ffe61ffa27b0a8e66c36f8615a9b3904780feaaf7290ebe2605f" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.13.Dockerfile
+++ b/docker/v2.0.13.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.13/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.13/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "2b5b060116afa81cbedcc5474ccc6768ba668791bc1472a9e0f459e5ddc0fadf" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.14.Dockerfile
+++ b/docker/v2.0.14.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.14/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.14/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "13de4601117c4c59df9e8b7c2a1be28df6d181f8638bf89350de90eafc8efdb2" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.15.Dockerfile
+++ b/docker/v2.0.15.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.15/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.15/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "d9bd525f5c2d929a6231a94d86848f0974b23ce113c6a41d1daefa5d00b82fe0" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.16.Dockerfile
+++ b/docker/v2.0.16.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.16/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.16/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "71711a89e2ec8d29ac0d809c611fc18f4b22424bc425ebc0a70cc9ddc236572e" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.17.Dockerfile
+++ b/docker/v2.0.17.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.17/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.17/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "6622b4d45d08f22b84f6874618dc0edb33568c5b58bd55ca4f6dee200df8a43f" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.18.Dockerfile
+++ b/docker/v2.0.18.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.18/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.18/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "1bded4ddae8e0244d7bbb5a1b9472b353b329b1ecaf7f35cf75217951a5599d1" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.19.Dockerfile
+++ b/docker/v2.0.19.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.19/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.19/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "e652b70f965b1cf91a8d65a0b9a8023f526f29c813298235b274171ecd01d735" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.2.Dockerfile
+++ b/docker/v2.0.2.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.2/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.2/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "d771ae75914597098ec2140c728f51ff1ccf96e2afbc48f8c691274e24909d59" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.20.Dockerfile
+++ b/docker/v2.0.20.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.20/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.20/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "e2b0a1fb329d6aae993a98341e3f3a67fa16e4134f11951944dcf3ed1d39f8b0" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.21.Dockerfile
+++ b/docker/v2.0.21.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.21/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.21/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "b34d184839fc6c3e2577eb1832c275f23724f422e4adaec1ba31aab1b00905b4" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.22.Dockerfile
+++ b/docker/v2.0.22.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.22/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.22/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "ec553106255fa6cfef6879b5689fe08d2e63a212cb29ea82794a0bb809268c20" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.23.Dockerfile
+++ b/docker/v2.0.23.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.23/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.23/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "7776bd05e60373ffd6b95c96bdaca027167db957b15e0964b145efb2aadbeead" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.24.Dockerfile
+++ b/docker/v2.0.24.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.24/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.24/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "72addbdfabdd6918aa9293f2cd6e0d55661c90fc6abe23d0655dba8059fe9a06" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.25.Dockerfile
+++ b/docker/v2.0.25.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.25/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.25/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "e0926f727a9282e029d0cf809763c0095752562d9b4893113d140071bb84a706" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.3.Dockerfile
+++ b/docker/v2.0.3.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.3/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.3/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "ab9f06bef845280d822a3c47bbfc859a1760aa1594dd97ada31640cff5add64e" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.4.Dockerfile
+++ b/docker/v2.0.4.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.4/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.4/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "9732b9fc29199b5e5e4497c7f03e7771f5326b0330a6890d2013437d3d8ae2ba" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.5.Dockerfile
+++ b/docker/v2.0.5.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.5/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.5/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "c4f238fe3dfaed3accf1939c62ac02195e9b57b45aaa7af6ee36ebec8a3abb69" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.6.Dockerfile
+++ b/docker/v2.0.6.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.6/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.6/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "7eecbd646d91530aa329ca9857c8ba81f958e7b073d957534488fcde54304eba" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.7.Dockerfile
+++ b/docker/v2.0.7.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.7/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.7/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "b5f89344ff729e7574c31e014222f8c761cc5c1fe44fe73b6f30114c51e78ca3" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.8.Dockerfile
+++ b/docker/v2.0.8.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.8/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.8/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "1485c041287b1240631c374772995660499606fdbf26246195d7307d962773eb" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.0.9.Dockerfile
+++ b/docker/v2.0.9.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:653bd24b9a8f9800c67df55fea5637a97152153fd744a4ef78dd41f7ddc40144
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.0.9/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.0.9/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "5153815847744b97059973681f94ad304d332f68528bfbc49b7e47d9f4664b3f" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.0.Dockerfile
+++ b/docker/v2.1.0.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.0/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.0/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "4e677148acc719e961ac51f4fd628ee1321cfbee7c7182134425629ef24c6909" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.1.Dockerfile
+++ b/docker/v2.1.1.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.1/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.1/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "353b7bdf17fefca0836dcb9bd06bba85ce427b9ece9ea1299cf905b0c3c26705" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.10.Dockerfile
+++ b/docker/v2.1.10.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.10/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.10/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "2de91ac04395fd0cc2611a9ae0c6ae6b09945295e239f42036a5a2d1281c7948" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.11.Dockerfile
+++ b/docker/v2.1.11.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.11/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.11/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "8a4c51e90c51cb3bbdff42c6f61b5fc52435ae6857268ca20d424808d61ffefc" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.13.Dockerfile
+++ b/docker/v2.1.13.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.13/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.13/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "75c08fc84f46e5f2509229fb4abf71347d0fe53eac722b034307b63677ebaa03" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.14.Dockerfile
+++ b/docker/v2.1.14.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.14/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.14/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "9b9b65ecdc1502975b93e1c79754b2db6841410b5e0882500656417ce3ee2e8c" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.15.Dockerfile
+++ b/docker/v2.1.15.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.15/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.15/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "2d4ac7abd8f3263c5ccca545f990b84d999ae0ee2e7d88e9ded18cb58b259d73" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.16.Dockerfile
+++ b/docker/v2.1.16.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.16/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.16/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "5b6c60eee02bdef5c1d9463a5be6c0728518f8f554e98ac15d2001e23b51f830" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.17.Dockerfile
+++ b/docker/v2.1.17.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.17/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.17/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "4a27a03e802921e9ddbc86bba821c07d02522d159eb27599e3996c6a3361ae0f" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.18.Dockerfile
+++ b/docker/v2.1.18.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.18/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.18/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "32d1aad50f0e5ad7b2b973a173406cebc32fe3c8ffa1aac66afd66fd63ffd289" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.2.Dockerfile
+++ b/docker/v2.1.2.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.2/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.2/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "9e59c86f832c0c6867eec1f18e0bbfa42a7d92acd4cdaf4e38218c439d99fb01" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.20.Dockerfile
+++ b/docker/v2.1.20.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.20/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.20/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "872c21d670fcc1ad61631fccbff38474d327a6171ffdbc04f085e58cb0b1edfb" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.21.Dockerfile
+++ b/docker/v2.1.21.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.21/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.21/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "67b3527884e617fe5dfb20d8fd2eb2269d236e84ab2ba2c563dc13b9bc2c2134" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.4.Dockerfile
+++ b/docker/v2.1.4.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.4/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.4/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "fe12630b5d9a5b8ceb0e4f1d6b98dc3ce447093e47cf5ebaa0584f3d03712681" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.5.Dockerfile
+++ b/docker/v2.1.5.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.5/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.5/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "3c1332efe28a89cdb29ae73f68005097873d65cf1db6b76a623a4c517950eff6" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.6.Dockerfile
+++ b/docker/v2.1.6.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.6/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.6/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "4ca594a4b87f9c68ba2ba85f21d32dbdc0f8126c6d45f8ad4e90e6177d9065d0" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.7.Dockerfile
+++ b/docker/v2.1.7.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.7/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.7/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "12f1d8ac0e51dccbf020c907cfadf2c7f70f78cdc42557a5c136d809591b85b3" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.8.Dockerfile
+++ b/docker/v2.1.8.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.8/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.8/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "b9c4157fff9e2ec9a2f889ad38c84e3fa84b00ebed63acb5bad8d4106a200466" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.1.9.Dockerfile
+++ b/docker/v2.1.9.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:62afc139057dc9d3eda02e490677911b55a208ba22d6f7315f3c5c5851e31a36
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.1.9/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.1.9/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "067f8198320dcac0770888a49901b0b1c51b67e315ab4d0e1942499544f466e6" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.0.Dockerfile
+++ b/docker/v2.2.0.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.0/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.0/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "e6b12fc486b5020eab6951c71f6527cdf4477e3e583e55a640a4b9f38fa65e1c" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.1.Dockerfile
+++ b/docker/v2.2.1.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.1/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.1/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "270f9b034f591d18c59c5abda426ed235e084a325d492b503572018109477441" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.10.Dockerfile
+++ b/docker/v2.2.10.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.10/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.10/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "9e8372c481857e029faac540a57d9149a95e96e121934cb2b4684a1b49e8a9dd" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.11.Dockerfile
+++ b/docker/v2.2.11.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.11/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.11/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "9c9fecb3c9c316ee4f03f0e19910239093bbaf88a3f64e1b6824f1d690a7f31e" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.12.Dockerfile
+++ b/docker/v2.2.12.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.12/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.12/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "1430da752981d0b3b09cb35d73adede97ec82f04a8e2d2fb0780d547b01c555a" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.13.Dockerfile
+++ b/docker/v2.2.13.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.13/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.13/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "a6e33d56d1becd251867f745f4db6ec88566a773cd765910d6371b942ad8a165" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.14.Dockerfile
+++ b/docker/v2.2.14.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.14/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.14/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "502bb652d251a7a97d5e3103ff18cc66cd3717cecb078f8fb185485cd29cf206" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.15.Dockerfile
+++ b/docker/v2.2.15.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.15/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.15/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "a38e5db860b084b44e30988df9aff89c21d2d7f3804799b9955339de626c2e9e" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.16.Dockerfile
+++ b/docker/v2.2.16.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.16/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.16/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "d7f9794d06e6124119bb89d39b0f65e7c99b60e8f90547fa299653599e5b73f6" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.17.Dockerfile
+++ b/docker/v2.2.17.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.17/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.17/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "ac6ff8a3680b09346c97a469af07f16c52601672016e8d27adffee87ba55de9b" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.18.Dockerfile
+++ b/docker/v2.2.18.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.18/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.18/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "1dddab096b437d0f874e4c63347032b77d8cac16d0ec320367ef775b08023daf" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.19.Dockerfile
+++ b/docker/v2.2.19.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.19/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.19/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "5784c778feef5268da25ef046021185e5a7dd4ed809d99ea1e16ba0d930dee47" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.2.Dockerfile
+++ b/docker/v2.2.2.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.2/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.2/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "c542769979cc9b1516d53f761ae9613ba6a713b366354d1773a20cdf4f5455e4" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.20.Dockerfile
+++ b/docker/v2.2.20.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.20/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.20/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "4caed81545b20ddcbc06d65ca8ef8dc69fc9e68fe93a868f5b508309021b49af" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.3.Dockerfile
+++ b/docker/v2.2.3.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.3/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.3/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "271a8eb17576a0bfdf0edf4b33d32150835d225c34c3d690a024c4565ec649f4" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.4.Dockerfile
+++ b/docker/v2.2.4.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.4/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.4/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "31bafe3fcf19814a3ea039e81e2d79bf79e08d18b2779370ff69a77bf2622993" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.5.Dockerfile
+++ b/docker/v2.2.5.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.5/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.5/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "604b48de2baa20895d9734d9210944b19401efa2be5515d4322ddd305f48ef71" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.6.Dockerfile
+++ b/docker/v2.2.6.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.6/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.6/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "07fb92866b568bfc44407f76b0b537b6d3e727cdedef3507ec96c9ce80686cdb" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.7.Dockerfile
+++ b/docker/v2.2.7.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.7/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.7/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "a9e90177db9d521e08352d296b084ba98d38b2d6341d40613f95af02b29f3691" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.8.Dockerfile
+++ b/docker/v2.2.8.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.8/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.8/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "7e812f9d7947c8e5f6cc57f05379dc07ab07b7373a4b11aba3d28b7ca6b55ba6" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.2.9.Dockerfile
+++ b/docker/v2.2.9.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:479476fa1dec14dfa9ed2dbcaa94cda5ab945e125d45c2d153267cc0135f3b69
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.2.9/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.2.9/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "3c3796551bc6770a560156c273334e8ac0a22b732a741d7d2598bb3a27d5f5df" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.0.Dockerfile
+++ b/docker/v2.3.0.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.0/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.0/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "1a3f28b6108a0dd7027c4349e65d040040d47dbc2baddee96c798ef6357caeb1" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.1.Dockerfile
+++ b/docker/v2.3.1.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.1/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.1/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "18560e1008d874705377ee2552d43eef4151062825d28aa0cf5f64229dcf21b9" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.10.Dockerfile
+++ b/docker/v2.3.10.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.10/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.10/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "868d304f1f0c4017f6aa8b4f3ed1253b784c032888990d0090fdf9d9023d1cbf" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.11.Dockerfile
+++ b/docker/v2.3.11.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.11/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.11/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "d546ac26afbb8c26e77541e8d37fd114b9528685c9302fe5e4554bb6aed40f4e" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.12.Dockerfile
+++ b/docker/v2.3.12.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.12/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.12/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "b5c97a10c239ae78c1f12f9dd71648a2a2cef2c6f8986ad68d8f52fc198507ba" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.13.Dockerfile
+++ b/docker/v2.3.13.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.13/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.13/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "44f37013c80bf1122067b250da38339a0b061dafde1f4162f037b4ce0008afa5" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.2.Dockerfile
+++ b/docker/v2.3.2.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.2/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.2/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "4913d37776b7968920f22b76dcbf5912199db9fb39eb3648479ee50e78227455" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.3.Dockerfile
+++ b/docker/v2.3.3.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.3/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.3/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "557f997a35d041ca99f0f403c92f312af2aa76c2a8dba7a0f736d3a63a41c065" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.4.Dockerfile
+++ b/docker/v2.3.4.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.4/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.4/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "d0a58ced94f609bd648b4644c34e8e6c9ae5200fb18a650ea0a19b8fe751abae" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.5.Dockerfile
+++ b/docker/v2.3.5.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.5/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.5/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "bcc21e0f67a774a8aeb77d9783d1d60797f8b6f46fcc2a3925a3b77e4668cbd3" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.6.Dockerfile
+++ b/docker/v2.3.6.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.6/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.6/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "83dca31947a64da261a56825390d673eea5d6d90e4651515d3ba4fb52832914d" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.7.Dockerfile
+++ b/docker/v2.3.7.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.7/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.7/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "6c5d2cf966960810ff3a7f60bfb6e3d615e34a72628acd42417bf6785d99c3f9" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.8.Dockerfile
+++ b/docker/v2.3.8.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.8/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.8/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "d9d49aa279517744c80cbb33571be2797925e9579a6030023d5b57848ef4f127" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v2.3.9.Dockerfile
+++ b/docker/v2.3.9.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v2.3.9/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v2.3.9/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "71e01a6ab30344ffb405d0f61ed7eb18604c6f0635b413bfbd372dc7aa36eeca" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.0.Dockerfile
+++ b/docker/v3.0.0.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.0/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.0/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "7d588d188cb9ea550434cabc62a9927cf75de22e1aeb2a87f2352071812944fb" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.1.Dockerfile
+++ b/docker/v3.0.1.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.1/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.1/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "70f6c6ab2021d1ffc3b06e6991ce0c5355880478a189accbe6a74d087b511081" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.10.Dockerfile
+++ b/docker/v3.0.10.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.10/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.10/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "a226d90def03484f145bdb5639053e419a817557344b3b76d1fc74f8d5f9bf3f" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.11.Dockerfile
+++ b/docker/v3.0.11.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.11/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.11/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "13fdf4a0c4e3fa32cd515fa87940851aece781edc80240743e9f930a364934a7" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.12.Dockerfile
+++ b/docker/v3.0.12.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.12/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.12/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "9aec455a49da4ca083a37b1cb6548212762b53467076656b0582fbbca1ad5a3a" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.13.Dockerfile
+++ b/docker/v3.0.13.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.13/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.13/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "dfab59a5773be04a284501f276a58a7856e2f42ae6ea68564140d0b3a56ce8c6" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.14.Dockerfile
+++ b/docker/v3.0.14.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.14/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.14/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "81650a27f21bc8eebff3b988abbc58c257c9d89f7edb8c2c3f89ef309b2d4ff2" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.2.Dockerfile
+++ b/docker/v3.0.2.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.2/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.2/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "f79bea7d2afc9e3e2cf312cb557632114d7cb363b752d1b9bec57dfa33069f91" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.3.Dockerfile
+++ b/docker/v3.0.3.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.3/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.3/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "38d9c4c9eda7882f76e1fc0006a49743f59bff9266718689274f4f630666da6e" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.4.Dockerfile
+++ b/docker/v3.0.4.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.4/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.4/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "95e76dccebea5a976cb60cb1c0a1e8ec18a9b289f244893f5b0d9034cd497ee4" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.5.Dockerfile
+++ b/docker/v3.0.5.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.5/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.5/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "1eb99156fa3cdf0060172a398d097ab7403634725b5188e3e1317c2479700071" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.6.Dockerfile
+++ b/docker/v3.0.6.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.6/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.6/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "aaeb20915a39608bbf10b13aa78bdaafd62c87747dd9d3220ec031daa4963e17" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.7.Dockerfile
+++ b/docker/v3.0.7.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.7/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.7/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "a73f700f95efcaf058d15cf75a58b91b1d89a26183c7aee72cefd0e29ecbab4c" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.8.Dockerfile
+++ b/docker/v3.0.8.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.8/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.8/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "c2a487e9990dc7f7211ce0ccb42c0c749fa3a839be1bee443ddb62c78c5ed25e" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.0.9.Dockerfile
+++ b/docker/v3.0.9.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.9/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.0.9/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "50c16eacd9727270a7accd688200046ad3e78c896b1fbfa057953525fe455d69" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.1.Dockerfile
+++ b/docker/v3.1.1.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.1/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.1/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "3765a3c91e759ae28705bca961941093c78636ead3c444ec040fd2a3a3608c12" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.10.Dockerfile
+++ b/docker/v3.1.10.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.10/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.10/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "dfd8afbff06d8c0302e11c2fbead5464d5c773097af97c772f3df8470677e130" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.2.Dockerfile
+++ b/docker/v3.1.2.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.2/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.2/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "13fa9fbf4716403d273a8aeef55536d7fc08b3e4654f92b325a47ba4b39ca4c9" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.3.Dockerfile
+++ b/docker/v3.1.3.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.3/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.3/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "ce556dca942ccd4d11b9b82bae81beeb5cd6c9b0dd2d96d22a0d8b815b72453f" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.4.Dockerfile
+++ b/docker/v3.1.4.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.4/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.4/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "5e86651ba7ff417840f9b0bf6367bf8ac2f573a1f1326df19bcf536c74751e49" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.5.Dockerfile
+++ b/docker/v3.1.5.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.5/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.5/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "c8d6b830fcdc286009822a1af25c6ddf377b05893e5ee429c380da0e061344ca" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.6.Dockerfile
+++ b/docker/v3.1.6.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.6/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.6/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "6887cf357abc2b901162eb79d128c9f0f0ab381ee504241936041fee9032c45c" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.7.Dockerfile
+++ b/docker/v3.1.7.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.7/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.7/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "cc7cef414c51f911723b63eef0e59a981bf46362201e8e653990958e29918ce4" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.8.Dockerfile
+++ b/docker/v3.1.8.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.8/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.8/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "fd94fa2c3eac88b60b1c5fd65e762decbfa5a467311d8dccb9d45029a9156175" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/docker/v3.1.9.Dockerfile
+++ b/docker/v3.1.9.Dockerfile
@@ -1,7 +1,12 @@
 FROM --platform=linux/amd64 rust@sha256:878ca0e8df1305dcbbfffac5bb908cce6a4bc5f6b629c518e7112645ee8851d4
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.9/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+RUN curl -sSfL "https://release.anza.xyz/v3.1.9/install" -o /tmp/solana_install.sh && \
+    ACTUAL=$(sha256sum /tmp/solana_install.sh | awk '{print $1}') && \
+    test "$ACTUAL" = "81d4fecf853abcd8ae4c5670c5dfc83235f8f36b6f092019ea3fdbc5c6de4564" && \
+    sh /tmp/solana_install.sh && \
+    rm -f /tmp/solana_install.sh
+
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -1,14 +1,23 @@
 import subprocess
 import os
 import argparse
+import glob
 import requests
 import tomllib
 import re
+import hashlib
+import time
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--upload", action="store_true")
 parser.add_argument("--skip_cache", action="store_true")
 parser.add_argument("--version")
+parser.add_argument("--update_existing", action="store_true", help="Overwrite existing docker/v*.Dockerfile files.")
+parser.add_argument(
+    "--only_existing",
+    action="store_true",
+    help="When used with --update_existing, only update Dockerfiles that already exist locally.",
+)
 args = parser.parse_args()
 
 # Array of Solana version mapped to rust version hashes
@@ -19,13 +28,41 @@ RUST_DOCKER_IMAGESHA_MAP = {
 RUST_VERSION_PLACEHOLDER = "$RUST_VERSION"
 SOLANA_VERSION_PLACEHOLDER = "$SOLANA_VERSION"
 AGAVE_VERSION_PLACEHOLDER = "$AGAVE_VERSION"
+INSTALL_SHA256_PLACEHOLDER = "$INSTALL_SHA256"
 
-# Dockerfile template for Solana versions >= 1.15
+_INSTALL_SHA256_CACHE = {}
+
+def fetch_install_script_sha256(url: str) -> str:
+    if url in _INSTALL_SHA256_CACHE:
+        return _INSTALL_SHA256_CACHE[url]
+
+    for _ in range(3):
+        try:
+            resp = requests.get(url, timeout=30)
+            resp.raise_for_status()
+            sha = hashlib.sha256(resp.content).hexdigest()
+            _INSTALL_SHA256_CACHE[url] = sha
+            return sha
+        except Exception:
+            time.sleep(2)
+
+    _INSTALL_SHA256_CACHE[url] = None
+    return None
+
+def with_pinned_installer(url: str, install_path: str = "/tmp/solana_install.sh") -> str:
+    return (
+        f'RUN curl -sSfL "{url}" -o {install_path} && \\\n'
+        f'    ACTUAL=$(sha256sum {install_path} | awk \'{{print $1}}\') && \\\n'
+        f'    test "$ACTUAL" = "{INSTALL_SHA256_PLACEHOLDER}" && \\\n'
+        f"    sh {install_path} && \\\n"
+        f"    rm -f {install_path}\n"
+    )
+
 base_dockerfile_sol = f"""
 FROM --platform=linux/amd64 rust@{RUST_VERSION_PLACEHOLDER}
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/{SOLANA_VERSION_PLACEHOLDER}/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+{with_pinned_installer(f"https://release.solana.com/{SOLANA_VERSION_PLACEHOLDER}/install")}
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 
@@ -36,10 +73,12 @@ CMD /bin/bash
 base_dockerfile_sol_pre15 = f"""
 FROM --platform=linux/amd64 rust@{RUST_VERSION_PLACEHOLDER}
 
-RUN apt-get update && apt-get install -qy git gnutls-bin curl
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
 
 # Download and modify the Solana install script to install the specified version
 RUN curl -sSfL "https://release.solana.com/v1.18.20/install" -o solana_install.sh && \\
+    ACTUAL=$(sha256sum solana_install.sh | awk '{{print $1}}') && \\
+    test "$ACTUAL" = "{INSTALL_SHA256_PLACEHOLDER}" && \\
     chmod +x solana_install.sh && \\
     sed -i "s/^SOLANA_INSTALL_INIT_ARGS=.*/SOLANA_INSTALL_INIT_ARGS={SOLANA_VERSION_PLACEHOLDER}/" solana_install.sh && \\
     ./solana_install.sh && \\
@@ -54,8 +93,8 @@ CMD /bin/bash
 base_dockerfile_agave = f"""
 FROM --platform=linux/amd64 rust@{RUST_VERSION_PLACEHOLDER}
 
-RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.anza.xyz/{AGAVE_VERSION_PLACEHOLDER}/install)"
+RUN apt-get update && apt-get install -qy git gnutls-bin curl ca-certificates
+{with_pinned_installer(f"https://release.anza.xyz/{AGAVE_VERSION_PLACEHOLDER}/install")}
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Call cargo build-sbf to trigger installation of associated platform tools
 RUN cargo init temp --edition 2021 && \\
@@ -102,29 +141,30 @@ def get_release_info(version_tag):
     
     # All releases 14 and below have a broken installer, so we need to use a custom script with a newer installer
     if (major == 1 and minor < 15):
-        release_info = {
+        return {
             "base_dockerfile_text": base_dockerfile_sol_pre15,
             "version_placeholder": SOLANA_VERSION_PLACEHOLDER,
-            "url": f"https://raw.githubusercontent.com/solana-labs/solana/{version_tag}/rust-toolchain.toml"
+            "url": f"https://raw.githubusercontent.com/solana-labs/solana/{version_tag}/rust-toolchain.toml",
+            "install_url": "https://release.solana.com/v1.18.20/install"
         }
     # Everything from 1.15.0 to 1.18.24 we want to get from solana labs 
     elif (major == 1 and minor >= 15) and not (minor == 18 and patch >= 24):
-        release_info = {
+        return {
             "base_dockerfile_text": base_dockerfile_sol,
             "version_placeholder": SOLANA_VERSION_PLACEHOLDER,
-            "url": f"https://raw.githubusercontent.com/solana-labs/solana/{version_tag}/rust-toolchain.toml"
+            "url": f"https://raw.githubusercontent.com/solana-labs/solana/{version_tag}/rust-toolchain.toml",
+            "install_url": f"https://release.solana.com/{version_tag}/install"
         }
     #Everything after we need to get from anza 
     elif (major == 1 and minor == 18 and patch >= 24) or major >= 2:
-        release_info = {
+        return {
             "base_dockerfile_text": base_dockerfile_agave,
             "version_placeholder": AGAVE_VERSION_PLACEHOLDER,
-            "url": f"https://raw.githubusercontent.com/anza-xyz/agave/{version_tag}/rust-toolchain.toml"
+            "url": f"https://raw.githubusercontent.com/anza-xyz/agave/{version_tag}/rust-toolchain.toml",
+            "install_url": f"https://release.anza.xyz/{version_tag}/install"
         }
-    else:
-        print(f"Skipping {version_tag} as it does not meet Solana or Agave criteria.")
-        return None
-    return release_info
+
+    return None
 
 # Function to get Solana releases
 def get_solana_releases():
@@ -150,6 +190,19 @@ def get_agave_releases():
     ]
     return tags
 
+def get_existing_docker_releases():
+    """
+    Returns release tags from existing dockerfiles only.
+    Used to avoid network calls when we only need to update already-checked-in Dockerfiles.
+    """
+    releases = []
+    for path in glob.glob("docker/v*.Dockerfile"):
+        base = os.path.basename(path)
+        if not base.endswith(".Dockerfile"):
+            continue
+        releases.append(base[: -len(".Dockerfile")])  # keep leading "v"
+    return sorted(set(releases))
+
 # Function to get Rust toolchain for each release
 def get_toolchain(version_tag):
     if "v1.14" in version_tag:
@@ -159,14 +212,11 @@ def get_toolchain(version_tag):
     if release_info is None:
         return None
 
-    url = release_info["url"]
-    response = requests.get(url, headers={"Accept": "application/vnd.github.v3.raw"})
+    response = requests.get(release_info["url"], headers={"Accept": "application/vnd.github.v3.raw"})
     if response.status_code == 200:
         parsed_data = tomllib.loads(response.text)
         return parsed_data["toolchain"]["channel"]
-    print(f"Failed to fetch rust-toolchain.toml for {version_tag}")
-    # Fallback to rust-version.ci for older versions
-    print(f"Attempting to retrieve Rust version from rust-version.ci for {version_tag}")
+
     return get_rust_version_from_ci(version_tag)
 
 def get_rust_version_from_ci(version_tag):
@@ -187,6 +237,10 @@ def process_releases(releases):
     for release in releases:
         release_info = get_release_info(release)
         if release_info is None:
+            continue
+
+        path = f"docker/{release}.Dockerfile"
+        if args.only_existing and not os.path.exists(path):
             continue
 
         base_dockerfile_text = release_info["base_dockerfile_text"]
@@ -218,26 +272,47 @@ def process_releases(releases):
             RUST_VERSION_PLACEHOLDER, RUST_DOCKER_IMAGESHA_MAP[rust_version]
         ).lstrip("\n")
 
-        path = f"docker/{release}.Dockerfile"
+        if os.path.exists(path):
+            if not args.update_existing:
+                # Only generate Dockerfiles for new releases
+                continue
+
+        sha = fetch_install_script_sha256(release_info["install_url"])
+        if not sha:
+            print(f"Warning: failed to fetch installer checksum for {release}; leaving {path} unchanged")
+            continue
+
+        dockerfile = dockerfile.replace(INSTALL_SHA256_PLACEHOLDER, sha)
+
+        if INSTALL_SHA256_PLACEHOLDER in dockerfile:
+            raise Exception(f"Checksum not injected for {release}")
+
+        stripped = release.strip("v")
         if os.path.exists(path):
             with open(path, "r") as f:
-                if f.read() != dockerfile:
-                    dirty_set.add(release.strip("v"))
+                unchanged = f.read() == dockerfile
         else:
-            dirty_set.add(release.strip("v"))
-        with open(path, "w") as f:
-            f.write(dockerfile)
+            unchanged = False
+
+        if not unchanged:
+            dirty_set.add(stripped)
+            with open(path, "w") as f:
+                f.write(dockerfile)
         dockerfiles[release] = path
 
 # Main execution
-solana_releases = get_solana_releases()
-agave_releases = get_agave_releases()
-
 dockerfiles = {}
 dirty_set = set()
 
-process_releases(solana_releases)
-process_releases(agave_releases)
+if args.update_existing and args.only_existing:
+    # Only update already present dockerfiles
+    releases = get_existing_docker_releases()
+    process_releases(releases)
+else:
+    solana_releases = get_solana_releases()
+    agave_releases = get_agave_releases()
+    process_releases(solana_releases)
+    process_releases(agave_releases)
 
 print(RUST_DOCKER_IMAGESHA_MAP)
 
@@ -251,11 +326,7 @@ if not args.skip_cache:
     for result in response.json()["results"]:
         print(result)
         if result["name"] != "latest":
-            try:
-                digest_set.add(result["name"])
-            except Exception as e:
-                print(e)
-                continue
+            digest_set.add(result["name"])
 
 if args.upload:
     print("Uploading all Dockerfiles")
@@ -273,7 +344,7 @@ if args.upload:
             if len(ver) == 2:
                 a_major, a_minor = ver
                 a_patch = patch
-            if len(ver) == 3:
+            else:
                 a_major, a_minor, a_patch = ver
             if major != a_major or minor != a_minor or a_patch != patch:
                 print(f"Skipping {stripped_tag}")
@@ -289,6 +360,7 @@ if args.upload:
             continue
         if stripped_tag in dirty_set:
             print(f"Dockerfile for {stripped_tag} needs to be modified")
+
         version_tag = f"solana:{stripped_tag}"
         print(version_tag)
         current_directory = os.getcwd()


### PR DESCRIPTION
### Problem
Dockerfiles were installing Solana/Agave using `curl | sh`, so the installer wasn’t verified or pinned.

### Solution
Added checksum verification to the Dockerfiles:
- Download installer script
- Verify SHA256 against a pinned hash
- Only run if it matches
- This was added to generate_dockerfiles.py and applied to existing Dockerfiles.

### Updates
Added a manual workflow to regenerate checksums and open a PR when needed
